### PR TITLE
Implement exists

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -815,6 +815,50 @@ fn simple_dict_lookup() {
     unsafe { weld_value_free(ret_value) };
 }
 
+fn simple_dict_exists() {
+    #[allow(dead_code)]
+    struct Args {
+        x: WeldVec<i32>,
+        y: WeldVec<i32>,
+    }
+
+    let keys = [1, 2, 2, 1, 3];
+    let vals = [2, 3, 4, 2, 1];
+
+    let code_true = "|x:vec[i32], y:vec[i32]| let a = result(for(zip(x,y), dictmerger[i32,i32,+], \
+                |b,i,e| merge(b, e))); exists(a, 1)";
+    let code_false = "|x:vec[i32], y:vec[i32]| let a = result(for(zip(x,y), dictmerger[i32,i32,+], \
+                |b,i,e| merge(b, e))); exists(a, 4)";
+    let conf = default_conf();
+
+    let ref input_data = Args {
+        x: WeldVec {
+            data: &keys as *const i32,
+            len: keys.len() as i64,
+        },
+        y: WeldVec {
+            data: &vals as *const i32,
+            len: vals.len() as i64,
+        },
+    };
+
+    let ret_value = compile_and_run(code_true, conf, input_data.clone());
+    let data = unsafe { weld_value_data(ret_value) as *const bool };
+    let result = unsafe { (*data).clone() };
+
+    let output = true;
+    assert_eq!(output, result);
+
+    let conf2 = default_conf();
+    let ret_value2 = compile_and_run(code_false, conf2, input_data.clone());
+    let data = unsafe { weld_value_data(ret_value2) as *const bool };
+    let result = unsafe { (*data).clone() };
+
+    let output = false;
+    assert_eq!(output, result);
+    unsafe { weld_value_free(ret_value) };
+}
+
 fn simple_length() {
     let code = "|x:vec[i32]| len(x)";
     let conf = default_conf();
@@ -1110,6 +1154,7 @@ fn main() {
              ("simple_for_dictmerger_loop", simple_for_dictmerger_loop),
              ("simple_parallel_for_dictmerger_loop", simple_parallel_for_dictmerger_loop),
              ("simple_dict_lookup", simple_dict_lookup),
+             ("simple_dict_exists", simple_dict_exists),
              ("simple_length", simple_length),
              ("filter_length", filter_length),
              ("flat_map_length", flat_map_length),

--- a/weld/ast.rs
+++ b/weld/ast.rs
@@ -132,6 +132,10 @@ pub enum ExprKind<T: TypeBounds> {
         data: Box<Expr<T>>,
         index: Box<Expr<T>>,
     },
+    Exists {
+        data: Box<Expr<T>>,
+        key: Box<Expr<T>>,
+    },
     Slice {
         data: Box<Expr<T>>,
         index: Box<Expr<T>>,
@@ -264,6 +268,7 @@ impl<T: TypeBounds> Expr<T> {
                 GetField { ref expr, .. } => vec![expr.as_ref()],
                 Length { ref data } => vec![data.as_ref()],
                 Lookup { ref data, ref index } => vec![data.as_ref(), index.as_ref()],
+                Exists { ref data, ref key } => vec![data.as_ref(), key.as_ref()],
                 Slice { ref data, ref index, ref size } => {
                     vec![data.as_ref(), index.as_ref(), size.as_ref()]
                 }
@@ -325,6 +330,7 @@ impl<T: TypeBounds> Expr<T> {
                 GetField { ref mut expr, .. } => vec![expr.as_mut()],
                 Length { ref mut data } => vec![data.as_mut()],
                 Lookup { ref mut data, ref mut index } => vec![data.as_mut(), index.as_mut()],
+                Exists { ref mut data, ref mut key } => vec![data.as_mut(), key.as_mut()],
                 Slice { ref mut data, ref mut index, ref mut size } => {
                     vec![data.as_mut(), index.as_mut(), size.as_mut()]
                 }
@@ -425,6 +431,7 @@ impl<T: TypeBounds> Expr<T> {
                 }
                 (&Length { .. }, &Length { .. }) => Ok(true),
                 (&Lookup { .. }, &Lookup { .. }) => Ok(true),
+                (&Exists { .. }, &Exists { .. }) => Ok(true),
                 (&Slice { .. }, &Slice { .. }) => Ok(true),
                 (&Exp { .. }, &Exp { .. }) => Ok(true),
                 (&Merge { .. }, &Merge { .. }) => Ok(true),

--- a/weld/llvm.rs
+++ b/weld/llvm.rs
@@ -1226,6 +1226,41 @@ impl LlvmGenerator {
                             _ => weld_err!("Illegal type {} in Lookup", print_type(child_ty))?,
                         }
                     }
+                    Exists { ref output, ref child, ref key } => {
+                        let child_ty = try!(get_sym_ty(func, child));
+                        match *child_ty {
+                            Dict(_, _) => {
+                                let child_ll_ty = try!(self.llvm_type(&child_ty)).to_string();
+                                let dict_ll_ty = try!(self.llvm_type(&child_ty)).to_string();
+                                let key_ty = try!(get_sym_ty(func, key));
+                                let key_ll_ty = try!(self.llvm_type(&key_ty)).to_string();
+                                let dict_prefix = format!("@{}", dict_ll_ty.replace("%", ""));
+                                let child_tmp = try!(self.load_var(llvm_symbol(child).as_str(),
+                                    &child_ll_ty, ctx));
+                                let key_tmp = try!(self.load_var(llvm_symbol(key).as_str(),
+                                    &key_ll_ty, ctx));
+                                let slot = ctx.var_ids.next();
+                                let res_tmp = ctx.var_ids.next();
+                                ctx.code.add(format!("{} = call {}.slot {}.lookup({} {}, {} {})",
+                                                     slot,
+                                                     dict_ll_ty,
+                                                     dict_prefix,
+                                                     dict_ll_ty,
+                                                     child_tmp,
+                                                     key_ll_ty,
+                                                     key_tmp));
+                                ctx.code.add(format!("{} = call i1 {}.slot.filled({}.slot {})",
+                                                     res_tmp,
+                                                     dict_prefix,
+                                                     dict_ll_ty,
+                                                     slot));
+                                ctx.code.add(format!("store i1 {}, i1* {}",
+                                                     res_tmp,
+                                                     llvm_symbol(output)));
+                            }
+                            _ => weld_err!("Illegal type {} in Exists", print_type(child_ty))?,
+                        }
+                    }
                     Slice { ref output, ref child, ref index, ref size } => {
                         let child_ty = try!(get_sym_ty(func, child));
                         match *child_ty {

--- a/weld/parser.rs
+++ b/weld/parser.rs
@@ -654,6 +654,18 @@ impl<'t> Parser<'t> {
                 }))
             }
 
+            TExists => {
+                try!(self.consume(TOpenParen));
+                let data = try!(self.expr());
+                try!(self.consume(TComma));
+                let key = try!(self.expr());
+                try!(self.consume(TCloseParen));
+                Ok(expr_box(Exists {
+                    data: data,
+                    key: key,
+                }))
+            }
+
             TSlice => {
                 try!(self.consume(TOpenParen));
                 let data = try!(self.expr());

--- a/weld/partial_types.rs
+++ b/weld/partial_types.rs
@@ -232,6 +232,12 @@ impl PartialExpr {
                     index: try!(typed_box(index)),
                 }
             }
+            Exists { ref data, ref key } => {
+                Exists {
+                    data: try!(typed_box(data)),
+                    key: try!(typed_box(key)),
+                }
+            }
 
             Slice { ref data, ref index, ref size } => {
                 Slice {

--- a/weld/pretty_print.rs
+++ b/weld/pretty_print.rs
@@ -253,6 +253,11 @@ fn print_expr_impl<T: PrintableType>(expr: &Expr<T>,
                     print_expr_impl(data, typed, indent, should_indent),
                     print_expr_impl(index, typed, indent, should_indent))
         }
+        Exists { ref data, ref key } => {
+            format!("exists({},{})",
+                    print_expr_impl(data, typed, indent, should_indent),
+                    print_expr_impl(key, typed, indent, should_indent))
+        }
 
         Slice { ref data, ref index, ref size } => {
             format!("slice({},{},{})",

--- a/weld/sir.rs
+++ b/weld/sir.rs
@@ -32,6 +32,11 @@ pub enum Statement {
         child: Symbol,
         index: Symbol,
     },
+    Exists {
+        output: Symbol,
+        child: Symbol,
+        key: Symbol,
+    },
     Slice {
         output: Symbol,
         child: Symbol,
@@ -201,6 +206,9 @@ impl fmt::Display for Statement {
             Lookup { ref output, ref child, ref index } => {
                 write!(f, "{} = lookup({}, {})", output, child, index)
             }
+            Exists { ref output, ref child, ref key } => {
+                write!(f, "{} = exists({}, {})", output, child, key)
+            }
             Slice { ref output, ref child, ref index, ref size } => {
                 write!(f, "{} = slice({}, {}, {})", output, child, index, size)
             }
@@ -362,6 +370,10 @@ fn sir_param_correction_helper(prog: &mut SirProgram,
                 Lookup { ref child, ref index, .. } => {
                     vars.push(child.clone());
                     vars.push(index.clone());
+                }
+                Exists { ref child, ref key, .. } => {
+                    vars.push(child.clone());
+                    vars.push(key.clone());
                 }
                 Slice { ref child, ref index, ref size, .. } => {
                     vars.push(child.clone());
@@ -568,6 +580,18 @@ fn gen_expr(expr: &TypedExpr,
                 output: res_sym.clone(),
                 child: data_sym,
                 index: index_sym.clone(),
+            });
+            Ok((cur_func, cur_block, res_sym))
+        }
+
+        ExprKind::Exists { ref data, ref key } => {
+            let (cur_func, cur_block, data_sym) = gen_expr(data, prog, cur_func, cur_block)?;
+            let (cur_func, cur_block, key_sym) = gen_expr(key, prog, cur_func, cur_block)?;
+            let res_sym = prog.add_local(&expr.ty, cur_func);
+            prog.funcs[cur_func].blocks[cur_block].add_statement(Exists {
+                output: res_sym.clone(),
+                child: data_sym,
+                key: key_sym.clone(),
             });
             Ok((cur_func, cur_block, res_sym))
         }

--- a/weld/tokenizer.rs
+++ b/weld/tokenizer.rs
@@ -40,6 +40,7 @@ pub enum Token {
     TIter,
     TLen,
     TLookup,
+    TExists,
     TSlice,
     TExp,
     TAppender,
@@ -89,7 +90,7 @@ pub fn tokenize(input: &str) -> WeldResult<Vec<Token>> {
 
         // Regular expressions for various types of tokens.
         static ref KEYWORD_RE: Regex = Regex::new(
-            "if|for|zip|len|lookup|slice|exp|iter|merge|result|let|true|false|macro|\
+            "if|for|zip|len|lookup|exists|slice|exp|iter|merge|result|let|true|false|macro|\
              i8|i32|i64|f32|f64|bool|vec|appender|merger|vecmerger|dictmerger|tovec").unwrap();
 
         static ref IDENT_RE: Regex = Regex::new(r"^[A-Za-z$_][A-Za-z0-9$_]*$").unwrap();
@@ -143,6 +144,7 @@ pub fn tokenize(input: &str) -> WeldResult<Vec<Token>> {
                 "iter" => TIter,
                 "len" => TLen,
                 "lookup" => TLookup,
+                "exists" => TExists,
                 "slice" => TSlice,
                 "exp" => TExp,
                 "true" => TBoolLiteral(true),
@@ -266,6 +268,7 @@ impl fmt::Display for Token {
                            TIter => "iter",
                            TLen => "len",
                            TLookup => "lookup",
+                           TExists => "exists",
                            TSlice => "slice",
                            TExp => "exp",
                            TOpenParen => "(",
@@ -378,6 +381,14 @@ fn basic_tokenize() {
                     TExp,
                     TOpenParen,
                     TIdent("a".into()),
+                    TCloseParen,
+                    TEndOfInput]);
+    assert_eq!(tokenize("exists(a, 1)").unwrap(),
+               vec![TExists,
+                    TOpenParen,
+                    TIdent("a".into()),
+                    TComma,
+                    TI32Literal(1),
                     TCloseParen,
                     TEndOfInput]);
     assert!(tokenize("0a").is_err());

--- a/weld/type_inference.rs
+++ b/weld/type_inference.rs
@@ -280,6 +280,19 @@ fn infer_locally(expr: &mut PartialExpr, env: &mut TypeMap) -> WeldResult<bool> 
             }
         }
 
+        Exists { ref mut data, ref mut key } => {
+            if let Dict(ref key_type, _) = data.ty {
+                let mut changed = false;
+                changed |= try!(push_type(&mut key.ty, &key_type, "Exists"));
+                changed |= try!(push_complete_type(&mut expr.ty, Scalar(Bool), "Exists"));
+                Ok(changed)
+            } else if data.ty == Unknown {
+                Ok(false)
+            } else {
+                weld_err!("Internal error: Exists called on {:?}", data.ty)
+            }
+        }
+
         Lambda { ref mut params, ref mut body } => {
             let mut changed = false;
 
@@ -789,6 +802,13 @@ fn infer_types_let() {
     let mut e = parse_expr("let a = lookup(lookup([[1],[2],[3]], 0L), 0L); a").unwrap();
     assert!(infer_types(&mut e).is_ok());
     assert_eq!(e.ty, Scalar(I32));
+
+    let code = "let a = result(for([1,2,3], dictmerger[i32,i32,+], \
+                |b,i,e| merge(b, {e,e}))); exists(a, 1)";
+
+    let mut e = parse_expr(code).unwrap();
+    assert!(infer_types(&mut e).is_ok());
+    assert_eq!(e.ty,  Scalar(Bool));
 
     let mut e = parse_expr("let a = slice([1.0f, 2.0f, 3.0f], 0L, 2L);a").unwrap();
     assert!(infer_types(&mut e).is_ok());


### PR DESCRIPTION
Implements the exists operator.
Given a dict and a key returns true if the key exists and false if it doesn't.

Figured this should be committed separately from the python workload.